### PR TITLE
fix: handle non-null in arg parser

### DIFF
--- a/compatibility/Types/Product.cs
+++ b/compatibility/Types/Product.cs
@@ -43,7 +43,7 @@ public class Product
     public static Product? GetProductById(
         string id,
         Data repository)
-        => repository.Products.FirstOrDefault(t => t.Id.Equals(id));
+        => repository.Products.FirstOrDefault(t => id.Equals(t.Id));
 
     [ReferenceResolver]
     public static Product? GetProductByPackage(
@@ -51,8 +51,7 @@ public class Product
         string package,
         Data repository)
         => repository.Products.FirstOrDefault(
-            t => (t.Sku?.Equals(sku) ?? false) &&
-                (t.Package?.Equals(package) ?? false));
+            t => sku.Equals(t.Sku) && package.Equals(t.Package));
 
     [ReferenceResolver]
     public static Product? GetProductByVariation(
@@ -60,6 +59,6 @@ public class Product
         [Map("variation.id")] string variationId,
         Data repository)
         => repository.Products.FirstOrDefault(
-            t => (t.Sku?.Equals(sku) ?? false) &&
-                (t.Variation?.Id.Equals(variationId) ?? false));
+            t => sku.Equals(t.Sku) && variationId.Equals(t.Variation?.Id)
+        );
 }

--- a/compatibility/Types/ProductResearch.cs
+++ b/compatibility/Types/ProductResearch.cs
@@ -20,7 +20,6 @@ public class ProductResearch
         [Map("study.caseNumber")] string caseNumber,
         Data repository)
     {
-        Console.WriteLine("case number = {0}", caseNumber);
         return repository.ProductResearches.FirstOrDefault(
             r => r.Study.CaseNumber.Equals(caseNumber));
     }

--- a/src/Federation/Descriptors/EntityResolverDescriptor.cs
+++ b/src/Federation/Descriptors/EntityResolverDescriptor.cs
@@ -65,29 +65,6 @@ public sealed class EntityResolverDescriptor<TEntity>
 
     protected override EntityResolverDefinition Definition { get; set; } = new();
 
-    /// <inheritdoc cref="IEntityResolverDescriptor"/>
-    public IObjectTypeDescriptor ResolveReference(
-        FieldResolverDelegate fieldResolver)
-        => ResolveReference(fieldResolver, Array.Empty<string[]>());
-
-    private IObjectTypeDescriptor ResolveReference(
-        FieldResolverDelegate fieldResolver,
-        IReadOnlyList<string[]> required)
-    {
-        if (fieldResolver is null)
-        {
-            throw new ArgumentNullException(nameof(fieldResolver));
-        }
-
-        if (required is null)
-        {
-            throw new ArgumentNullException(nameof(required));
-        }
-
-        Definition.ResolverDefinition = new(fieldResolver, required);
-        return _typeDescriptor;
-    }
-
     /// <inheritdoc cref="IEntityResolverDescriptor{T}"/>
     public IObjectTypeDescriptor ResolveReferenceWith(
         Expression<Func<TEntity, object?>> method)
@@ -115,13 +92,6 @@ public sealed class EntityResolverDescriptor<TEntity>
     }
 
     /// <inheritdoc cref="IEntityResolverDescriptor"/>
-    public IObjectTypeDescriptor ResolveReferenceWith<TResolver>()
-        => ResolveReferenceWith(
-            Context.TypeInspector.GetNodeResolverMethod(
-                Definition.EntityType ?? typeof(TResolver),
-                typeof(TResolver))!);
-
-    /// <inheritdoc cref="IEntityResolverDescriptor"/>
     public IObjectTypeDescriptor ResolveReferenceWith(MethodInfo method)
     {
         if (method is null)
@@ -141,10 +111,21 @@ public sealed class EntityResolverDescriptor<TEntity>
         return ResolveReference(resolver.Resolver!, argumentBuilder.Required);
     }
 
-    /// <inheritdoc cref="IEntityResolverDescriptor"/>
-    public IObjectTypeDescriptor ResolveReferenceWith(Type type)
-        => ResolveReferenceWith(
-            Context.TypeInspector.GetNodeResolverMethod(
-                Definition.EntityType ?? type,
-                type)!);
+    private IObjectTypeDescriptor ResolveReference(
+        FieldResolverDelegate fieldResolver,
+        IReadOnlyList<string[]> required)
+    {
+        if (fieldResolver is null)
+        {
+            throw new ArgumentNullException(nameof(fieldResolver));
+        }
+
+        if (required is null)
+        {
+            throw new ArgumentNullException(nameof(required));
+        }
+
+        Definition.ResolverDefinition = new(fieldResolver, required);
+        return _typeDescriptor;
+    }
 }

--- a/src/Federation/Descriptors/IEntityResolverDescriptor.cs
+++ b/src/Federation/Descriptors/IEntityResolverDescriptor.cs
@@ -12,44 +12,6 @@ public interface IEntityResolverDescriptor
     /// <summary>
     /// Resolve an entity from its representation.
     /// </summary>
-    /// <param name="fieldResolver">
-    /// The resolver.
-    /// </param>
-    /// <returns>
-    /// Returns the descriptor for configuration chaining.
-    /// </returns>
-    IObjectTypeDescriptor ResolveReference(
-        FieldResolverDelegate fieldResolver);
-
-    /// <summary>
-    /// Resolve an entity from its representation.
-    /// </summary>
-    /// <param name="method">
-    /// The reference resolver selector.
-    /// </param>
-    /// <typeparam name="TResolver">
-    /// The type on which the reference resolver is located.
-    /// </typeparam>
-    /// <returns>
-    /// Returns the descriptor for configuration chaining.
-    /// </returns>
-    IObjectTypeDescriptor ResolveReferenceWith<TResolver>(
-        Expression<Func<TResolver, object?>> method);
-
-    /// <summary>
-    /// Resolve an entity from its representation.
-    /// </summary>
-    /// <typeparam name="TResolver">
-    /// The type on which the reference resolver is located.
-    /// </typeparam>
-    /// <returns>
-    /// Returns the descriptor for configuration chaining.
-    /// </returns>
-    IObjectTypeDescriptor ResolveReferenceWith<TResolver>();
-
-    /// <summary>
-    /// Resolve an entity from its representation.
-    /// </summary>
     /// <param name="method">
     /// The reference resolver.
     /// </param>
@@ -57,17 +19,6 @@ public interface IEntityResolverDescriptor
     /// Returns the descriptor for configuration chaining.
     /// </returns>
     IObjectTypeDescriptor ResolveReferenceWith(MethodInfo method);
-
-    /// <summary>
-    /// Resolve an entity from its representation.
-    /// </summary>
-    /// <param name="type">
-    /// The type on which the reference resolver is located.
-    /// </param>
-    /// <returns>
-    /// Returns the descriptor for configuration chaining.
-    /// </returns>
-    IObjectTypeDescriptor ResolveReferenceWith(Type type);
 }
 
 /// <summary>
@@ -75,18 +26,6 @@ public interface IEntityResolverDescriptor
 /// </summary>
 public interface IEntityResolverDescriptor<TEntity>
 {
-    /// <summary>
-    /// Resolve an entity from its representation.
-    /// </summary>
-    /// <param name="fieldResolver">
-    /// The resolver.
-    /// </param>
-    /// <returns>
-    /// Returns the descriptor for configuration chaining.
-    /// </returns>
-    IObjectTypeDescriptor ResolveReference(
-        FieldResolverDelegate fieldResolver);
-
     /// <summary>
     /// Resolve an entity from its representation.
     /// </summary>
@@ -103,47 +42,10 @@ public interface IEntityResolverDescriptor<TEntity>
     /// Resolve an entity from its representation.
     /// </summary>
     /// <param name="method">
-    /// The reference resolver selector.
-    /// </param>
-    /// <typeparam name="TResolver">
-    /// The type on which the reference resolver is located.
-    /// </typeparam>
-    /// <returns>
-    /// Returns the descriptor for configuration chaining.
-    /// </returns>
-    IObjectTypeDescriptor ResolveReferenceWith<TResolver>(
-        Expression<Func<TResolver, object?>> method);
-
-    /// <summary>
-    /// Resolve an entity from its representation.
-    /// </summary>
-    /// <typeparam name="TResolver">
-    /// The type on which the reference resolver is located.
-    /// </typeparam>
-    /// <returns>
-    /// Returns the descriptor for configuration chaining.
-    /// </returns>
-    IObjectTypeDescriptor ResolveReferenceWith<TResolver>();
-
-    /// <summary>
-    /// Resolve an entity from its representation.
-    /// </summary>
-    /// <param name="method">
     /// The reference resolver.
     /// </param>
     /// <returns>
     /// Returns the descriptor for configuration chaining.
     /// </returns>
     IObjectTypeDescriptor ResolveReferenceWith(MethodInfo method);
-
-    /// <summary>
-    /// Resolve an entity from its representation.
-    /// </summary>
-    /// <param name="type">
-    /// The type on which the reference resolver is located.
-    /// </param>
-    /// <returns>
-    /// Returns the descriptor for configuration chaining.
-    /// </returns>
-    IObjectTypeDescriptor ResolveReferenceWith(Type type);
 }

--- a/src/Federation/Helpers/ArgumentParser.cs
+++ b/src/Federation/Helpers/ArgumentParser.cs
@@ -31,10 +31,15 @@ internal static class ArgumentParser
         int i,
         out T? value)
     {
+        // TODO does not support list
         switch (valueNode.Kind)
         {
             case SyntaxKind.ObjectValue:
                 var current = path[i];
+                if (type.IsNonNullType())
+                {
+                    return TryGetValue(valueNode, type.InnerType(), path, i, out value);
+                }
 
                 if (type is not IComplexOutputType complexType ||
                     !complexType.Fields.TryGetField(current, out var field))
@@ -55,11 +60,9 @@ internal static class ArgumentParser
                     }
                 }
                 break;
-
             case SyntaxKind.NullValue:
                 value = default(T);
                 return true;
-
             case SyntaxKind.StringValue:
             case SyntaxKind.IntValue:
             case SyntaxKind.FloatValue:
@@ -115,6 +118,7 @@ internal static class ArgumentParser
     {
         switch (valueNode.Kind)
         {
+            // TODO does not handle list
             case SyntaxKind.ObjectValue:
                 var current = path[i];
 


### PR DESCRIPTION
Federated `ArgumentParser` is used to map entity representation to method arguments. When unwrapping nested fields, current logic was not accounting to nullability of the underlying field. If the underlying field returned non-null object, parser would fail trying to find the target property on `NonNull` GraphQL wrapper (which obviously doesn't exist).

Updated argument parser object handling logic to unwrap non-null types.

Note: this PR only addresses the issue with non-null types. Similar bug is present when handling keys with list representations.

Resolves: https://github.com/apollographql/federation-hotchocolate/issues/6