### PR TITLE
feat: allow users specifying supported federation version

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,9 +249,9 @@ app.Run();
 
 #### `@composedDirective` usage
 
-By default, Supergraph schema excludes all custom directives. The `@composeDirective`` is used to specify custom directives that should be preserved in the Supergraph schema.
+By default, Supergraph schema excludes all custom directives. The `@composeDirective` is used to specify custom directives that should be preserved in the Supergraph schema.
 
-`ApolloGraphQL.HotChocolate.Federation` provides common `FederatedSchema` class that automatically includes Apollo Federation v2 `@link` definition. When applying any custom
+`ApolloGraphQL.HotChocolate.Federation` provides common `FederatedSchema` class that automatically applies Apollo Federation v2 `@link` definition. When applying any custom
 schema directives, you should extend this class and add required attributes/directives.
 
 When applying `@composedDirective` you also need to `@link` it your specification. Your custom schema should then be passed to the `AddApolloFederationV2` extension.

--- a/README.md
+++ b/README.md
@@ -222,6 +222,31 @@ You can then generate your schema by running
 dotnet run -- schema export --output schema.graphql
 ```
 
+#### Specifying Federation Version
+
+By default, `ApolloGraphQL.HotChocolate.Federation` will generate schema using latest supported Federation version. If you would like to opt-in to use older versions you can
+so by specifying the version on your custom schema object and passing it to the `AddApolloFederationV2` extension.
+
+```csharp
+public class CustomSchema : FederatedSchema
+{
+    public CustomSchema() : base(FederationVersion.FEDERATION_23) {
+    }
+}
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services
+    .AddGraphQLServer()
+    .AddApolloFederationV2(new CustomSchema())
+    // register your types and services
+    ;
+
+var app = builder.Build();
+app.MapGraphQL();
+app.Run();
+```
+
 #### `@composedDirective` usage
 
 By default, Supergraph schema excludes all custom directives. The `@composeDirective`` is used to specify custom directives that should be preserved in the Supergraph schema.
@@ -296,7 +321,7 @@ public class Product
 }
 ```
 
-### Providing subgraph contact information
+#### Providing subgraph contact information
 
 You can use the `@contact` directive to add your team's contact information to a subgraph schema. This information is displayed in Studio, which helps *other* teams know who
 to contact for assistance with the subgraph. See [documentation](https://www.apollographql.com/docs/graphos/graphs/federated-graphs/#contact-info-for-subgraphs) for details.
@@ -351,6 +376,32 @@ While we tried to make migration process as seamless as possible, we had to make
 
 * `[Key]` is now applicable **only on classes** and you no longer can apply it on individual fields
 * `[ReferenceResolver]` is now applicable **only on public static methods within an entity**, it is no longer applicable on classes
+
+## Known Limitations
+
+#### Entity Resolver Auto-Map Only Scalar Values
+
+`[EntityResolver]`s can automatically map entity representation to the supported `@key`/`@requires` values. Scalars `@key` fields are automatically mapped and we can use `[Map]` attribute to auto map scalar values from complex selection sets.
+
+Currently we don't support auto-mapping of [List](https://github.com/apollographql/federation-hotchocolate/issues/19) and [Object](https://github.com/apollographql/federation-hotchocolate/issues/20) values.
+
+As a workaround, you need to manually parse the representation object in your implementation.
+
+```csharp
+[ReferenceResolver]
+public static Foo GetByFooBar(
+    [LocalState] ObjectValueNode data
+    Data repository)
+{
+    // TODO implement logic here by manually reading values from local state data
+}
+```
+
+#### Limited `@link` support
+
+Currently we only support importing elements from the referenced subgraphs.
+
+Namespacing and renaming elements is currently unsupported. See [issue](https://github.com/apollographql/federation-hotchocolate/issues/24) for details.
 
 ## Contact
 

--- a/src/Federation/Extensions/ApolloFederationSchemaBuilderExtensionsV2.cs
+++ b/src/Federation/Extensions/ApolloFederationSchemaBuilderExtensionsV2.cs
@@ -69,18 +69,40 @@ public static class ApolloFederationSchemaBuilderExtensionsV2
         builder.AddType(new ServiceType(true));
 
         // directives
-        builder.AddType<ComposeDirectiveType>();
-        builder.AddType<ExtendsDirectiveType>();
-        builder.AddType<ExternalDirectiveType>();
-        builder.AddType<InaccessibleDirectiveType>();
-        builder.AddType<InterfaceObjectirectiveType>();
-        builder.AddType<KeyV2>();
-        builder.AddType<LinkDirectiveType>();
-        builder.AddType<OverrideDirectiveType>();
-        builder.AddType<ProvidesV2>();
-        builder.AddType<RequiresV2>();
-        builder.AddType<ShareableDirectiveType>();
-        builder.AddType<TagDirectiveType>();
+        switch (schema.FederationVersion)
+        {
+            case FederationVersion.FEDERATION_25: // same as 2.3
+            case FederationVersion.FEDERATION_24: // same as 2.3
+            case FederationVersion.FEDERATION_23:
+                {
+                    builder.AddType<InterfaceObjectirectiveType>();
+                    goto case FederationVersion.FEDERATION_22;
+                }
+            case FederationVersion.FEDERATION_22: // same as 2.1
+            case FederationVersion.FEDERATION_21:
+                {
+                    builder.AddType<ComposeDirectiveType>();
+                    goto case FederationVersion.FEDERATION_20;
+                }
+            case FederationVersion.FEDERATION_20:
+                {
+                    builder.AddType<ExtendsDirectiveType>();
+                    builder.AddType<ExternalDirectiveType>();
+                    builder.AddType<InaccessibleDirectiveType>();
+                    builder.AddType<KeyV2>();
+                    builder.AddType<LinkDirectiveType>();
+                    builder.AddType<OverrideDirectiveType>();
+                    builder.AddType<ProvidesV2>();
+                    builder.AddType<RequiresV2>();
+                    builder.AddType<ShareableDirectiveType>();
+                    builder.AddType<TagDirectiveType>();
+                    break;
+                }
+            default:
+                {
+                    break;
+                }
+        }
         builder.TryAddTypeInterceptor<FederationTypeInterceptor>();
         return builder;
     }

--- a/src/Federation/Properties/FederationResources.Designer.cs
+++ b/src/Federation/Properties/FederationResources.Designer.cs
@@ -231,6 +231,14 @@ namespace ApolloGraphQL.HotChocolate.Federation.Properties
             }
         }
 
+        internal static string ThrowHelper_FederationVersion_Unknown
+        {
+            get
+            {
+                return ResourceManager.GetString("ThrowHelper_FederationVersion_Unknown", resourceCulture);
+            }
+        }
+
         internal static string ExpressionHelper_GetScopedStateWithDefault_NoDefaultValue
         {
             get

--- a/src/Federation/Properties/FederationResources.resx
+++ b/src/Federation/Properties/FederationResources.resx
@@ -183,6 +183,9 @@
     <data name="ThrowHelper_Contact_Name_CannotBeEmpty" xml:space="preserve">
     <value>The contact attribute is used on `{0}` without specifying the name.</value>
   </data>
+  <data name="ThrowHelper_FederationVersion_Unknown" xml:space="preserve">
+    <value>Specified federation version `{0}` is not supported.</value>
+  </data>
   <data name="FieldDescriptorExtensions_Key_FieldSet_CannotBeNullOrEmpty" xml:space="preserve">
     <value>Value cannot be null or empty.</value>
   </data>

--- a/src/Federation/ThrowHelper.cs
+++ b/src/Federation/ThrowHelper.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using FieldSetTypeV1 = ApolloGraphQL.HotChocolate.Federation.One.FieldSetType;
 using FieldSetTypeV2 = ApolloGraphQL.HotChocolate.Federation.Two.FieldSetType;
+using FederationVersion = ApolloGraphQL.HotChocolate.Federation.Two.FederationVersion;
 using static ApolloGraphQL.HotChocolate.Federation.Properties.FederationResources;
 
 namespace ApolloGraphQL.HotChocolate.Federation;
@@ -190,5 +191,17 @@ internal static class ThrowHelper
                 .SetMessage(
                     ThrowHelper_Contact_Name_CannotBeEmpty,
                     type.FullName ?? type.Name)
+                .Build());
+
+    /// <summary>
+    /// Specified federation version is not supported.
+    /// </summary>
+    public static SchemaException FederationVersion_Unknown(
+        FederationVersion version) =>
+        new SchemaException(
+            SchemaErrorBuilder.New()
+                .SetMessage(
+                    ThrowHelper_FederationVersion_Unknown,
+                    version)
                 .Build());
 }

--- a/src/Federation/Two/FederatedSchema.cs
+++ b/src/Federation/Two/FederatedSchema.cs
@@ -7,22 +7,24 @@ namespace ApolloGraphQL.HotChocolate.Federation.Two;
 /// <summary>
 /// Apollo Federation v2 base schema object that allows users to apply custom schema directives (e.g. @composeDirective)
 /// </summary>
-[Link("https://specs.apollo.dev/federation/v2.5", new string[] {
-                "@composeDirective",
-                "@extends",
-                "@external",
-                "@key",
-                "@inaccessible",
-                "@interfaceObject",
-                "@override",
-                "@provides",
-                "@requires",
-                "@shareable",
-                "@tag",
-                "FieldSet"
-})]
 public class FederatedSchema : Schema
 {
+    /// <summary>
+    /// Initializes new instance of <see cref="FederatedSchema"/>
+    /// </summary>
+    /// <param name="version">
+    /// Supported Apollo Federation version
+    /// </param>
+    public FederatedSchema(FederationVersion version = FederationVersion.FEDERATION_25)
+    {
+        FederationVersion = version;
+    }
+
+    /// <summary>
+    /// Retrieve supported Apollo Federation version
+    /// </summary>
+    public FederationVersion FederationVersion { get; }
+
     private IDescriptorContext _context = default!;
     protected override void OnAfterInitialize(ITypeDiscoveryContext context, DefinitionBase definition)
     {
@@ -43,5 +45,7 @@ public class FederatedSchema : Schema
                 }
             }
         }
+        var link = FederationUtils.GetFederationLink(FederationVersion);
+        descriptor.Link(link.Url, link.Import?.ToArray());
     }
 }

--- a/src/Federation/Two/FederationUtils.cs
+++ b/src/Federation/Two/FederationUtils.cs
@@ -30,7 +30,7 @@ internal sealed class FederationUtils
     private static List<string?> ConcatFederationImports(List<string?> baseImports, List<string?> additionalImports)
     {
         var imports = new List<string?>(baseImports);
-        imports.Concat(additionalImports);
+        imports.AddRange(additionalImports);
         return imports;
     }
 

--- a/src/Federation/Two/FederationUtils.cs
+++ b/src/Federation/Two/FederationUtils.cs
@@ -1,0 +1,80 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ApolloGraphQL.HotChocolate.Federation.Two;
+
+/// <summary>
+/// Utility class to help calculate different Apollo Federation @link imports based on the supported version.
+/// </summary>
+internal sealed class FederationUtils
+{
+    private static string FEDERATION_SPEC_BASE_URL = "https://specs.apollo.dev/federation/v";
+    private static List<string?> FEDERATION_IMPORTS_20 = new List<string?> {
+                "@extends",
+                "@external",
+                "@key",
+                "@inaccessible",
+                "@override",
+                "@provides",
+                "@requires",
+                "@shareable",
+                "@tag",
+                "FieldSet" };
+    private static List<string?> FEDERATION_IMPORTS_21 = ConcatFederationImports(FEDERATION_IMPORTS_20, new List<string?> { "@composeDirective" });
+    private static List<string?> FEDERATION_IMPORTS_22 = FEDERATION_IMPORTS_21;
+    private static List<string?> FEDERATION_IMPORTS_23 = ConcatFederationImports(FEDERATION_IMPORTS_22, new List<string?> { "@interfaceObject" });
+    private static List<string?> FEDERATION_IMPORTS_24 = FEDERATION_IMPORTS_23;
+    // TODO add @authenticated and @requiresPolicy
+    private static List<string?> FEDERATION_IMPORTS_25 = FEDERATION_IMPORTS_23;
+
+    private static List<string?> ConcatFederationImports(List<string?> baseImports, List<string?> additionalImports)
+    {
+        var imports = new List<string?>(baseImports);
+        imports.Concat(additionalImports);
+        return imports;
+    }
+
+    /// <summary>
+    /// Retrieve Apollo Federation @link information corresponding to the specified version.
+    /// </summary>
+    /// <param name="federationVersion">
+    /// Supported Apollo Federation version
+    /// </param>
+    /// <returns>
+    /// Federation @link information corresponding to the specified version.
+    /// </returns>
+    internal static Link GetFederationLink(FederationVersion federationVersion)
+    {
+        switch (federationVersion)
+        {
+            case FederationVersion.FEDERATION_20:
+                {
+                    return new Link(FEDERATION_SPEC_BASE_URL + "2.0", FEDERATION_IMPORTS_20);
+                }
+            case FederationVersion.FEDERATION_21:
+                {
+                    return new Link(FEDERATION_SPEC_BASE_URL + "2.1", FEDERATION_IMPORTS_21);
+                }
+            case FederationVersion.FEDERATION_22:
+                {
+                    return new Link(FEDERATION_SPEC_BASE_URL + "2.2", FEDERATION_IMPORTS_22);
+                }
+            case FederationVersion.FEDERATION_23:
+                {
+                    return new Link(FEDERATION_SPEC_BASE_URL + "2.3", FEDERATION_IMPORTS_23);
+                }
+            case FederationVersion.FEDERATION_24:
+                {
+                    return new Link(FEDERATION_SPEC_BASE_URL + "2.4", FEDERATION_IMPORTS_24);
+                }
+            case FederationVersion.FEDERATION_25:
+                {
+                    return new Link(FEDERATION_SPEC_BASE_URL + "2.5", FEDERATION_IMPORTS_25);
+                }
+            default:
+                {
+                    throw ThrowHelper.FederationVersion_Unknown(federationVersion);
+                }
+        }
+    }
+}

--- a/src/Federation/Two/FederationVersion.cs
+++ b/src/Federation/Two/FederationVersion.cs
@@ -1,0 +1,14 @@
+namespace ApolloGraphQL.HotChocolate.Federation.Two;
+
+/// <summary>
+/// Enum defining all supported Apollo Federation v2 versions.
+/// </summary>
+public enum FederationVersion
+{
+    FEDERATION_20,
+    FEDERATION_21,
+    FEDERATION_22,
+    FEDERATION_23,
+    FEDERATION_24,
+    FEDERATION_25,
+}


### PR DESCRIPTION
Instead of applying hard coded (and inherited) `[Link]` attribute, update `FederatedSchema` class to accept `FederationVersion` as a constructor parameter.