### PR TITLE
feat: support `@authenticated` and `@requiresScopes`

### DIFF
--- a/Federation/ApolloAuthenticatedAttribute.cs
+++ b/Federation/ApolloAuthenticatedAttribute.cs
@@ -1,0 +1,34 @@
+namespace ApolloGraphQL.HotChocolate.Federation;
+
+/// <summary>
+/// <code>
+/// directive @authenticated on
+///     ENUM
+///   | FIELD_DEFINITION
+///   | INTERFACE
+///   | OBJECT
+///   | SCALAR
+/// </code>
+/// 
+/// The @authenticated directive is used to indicate that the target element is accessible only to the authenticated supergraph users. 
+/// For more granular access control, see the <see cref="RequiresScopesDirectiveType">RequiresScopeDirectiveType</see> directive usage. 
+/// Refer to the <see href="https://www.apollographql.com/docs/router/configuration/authorization#authenticated">Apollo Router article</see> 
+/// for additional details.
+/// <example>
+/// type Foo @key(fields: "id") {
+///   id: ID
+///   description: String @authenticated
+/// }
+/// </example>
+/// </summary>
+[AttributeUsage(
+    AttributeTargets.Class
+    | AttributeTargets.Enum
+    | AttributeTargets.Interface
+    | AttributeTargets.Method
+    | AttributeTargets.Property
+    | AttributeTargets.Struct
+)]
+public sealed class ApolloAuthenticatedAttribute : Attribute
+{
+}

--- a/Federation/Constants/WellKnownArgumentNames.cs
+++ b/Federation/Constants/WellKnownArgumentNames.cs
@@ -7,5 +7,6 @@ internal static class WellKnownArgumentNames
     public const string Name = "name";
     public const string Resolvable = "resolvable";
     public const string Representations = "representations";
+    public const string Scopes = "scopes";
     public const string Url = "url";
 }

--- a/Federation/Constants/WellKnownTypeNames.cs
+++ b/Federation/Constants/WellKnownTypeNames.cs
@@ -2,21 +2,24 @@ namespace ApolloGraphQL.HotChocolate.Federation.Constants;
 
 internal static class WellKnownTypeNames
 {
+    public const string AuthenticatedDirective = "authenticated";
     public const string ContactDirective = "contact";
     public const string ComposeDirective = "composeDirective";
     public const string Extends = "extends";
     public const string External = "external";
     public const string Inaccessible = "inaccessible";
     public const string InterfaceObject = "interfaceObject";
-    public const string Requires = "requires";
-    public const string Provides = "provides";
     public const string Key = "key";
     public const string Link = "link";
     public const string Override = "override";
+    public const string Provides = "provides";
+    public const string Requires = "requires";
+    public const string RequiresScopes = "requiresScopes";
     public const string Shareable = "shareable";
     public const string Tag = "tag";
     public const string FieldSet = "_FieldSet";
     public const string FieldSetV2 = "FieldSet";
+    public const string Scope = "Scope";
     public const string Any = "_Any";
     public const string Entity = "_Entity";
     public const string Service = "_Service";

--- a/Federation/Extensions/ApolloFederationDescriptorExtensions~2.cs
+++ b/Federation/Extensions/ApolloFederationDescriptorExtensions~2.cs
@@ -22,10 +22,10 @@ public static partial class ApolloFederationDescriptorExtensions
     /// </example>
     /// </summary>
     /// <param name="descriptor">
-    /// The object field descriptor on which this directive shall be annotated.
+    /// The type descriptor on which this directive shall be annotated.
     /// </param>
     /// <returns>
-    /// Returns the object field descriptor.
+    /// Returns the type descriptor.
     /// </returns>
     /// <exception cref="ArgumentNullException">
     /// The <paramref name="descriptor"/> is <c>null</c>.

--- a/Federation/Extensions/ApolloFederationDescriptorExtensions~3.cs
+++ b/Federation/Extensions/ApolloFederationDescriptorExtensions~3.cs
@@ -18,13 +18,13 @@ public static partial class ApolloFederationDescriptorExtensions
     /// </example>
     /// </summary>
     /// <param name="descriptor">
-    /// The object field descriptor on which this directive shall be annotated.
+    /// The type descriptor on which this directive shall be annotated.
     /// </param>
     /// <param name="name">
     /// Tag value to be applied on the target
     /// </param>
     /// <returns>
-    /// Returns the object field descriptor.
+    /// Returns the type descriptor.
     /// </returns>
     /// <exception cref="ArgumentNullException">
     /// The <paramref name="descriptor"/> is <c>null</c>.

--- a/Federation/Extensions/ApolloFederationDescriptorExtensions~4.cs
+++ b/Federation/Extensions/ApolloFederationDescriptorExtensions~4.cs
@@ -1,0 +1,76 @@
+using ApolloGraphQL.HotChocolate.Federation.Constants;
+
+namespace HotChocolate.Types;
+
+/// <summary>
+/// Provides extensions for applying @authenticated directive on type system descriptors.
+/// </summary>
+public static partial class ApolloFederationDescriptorExtensions
+{
+    /// <summary>
+    /// Applies @authenticated directive to indicate that the target element is accessible only to the authenticated supergraph users.
+    /// <example>
+    /// type Foo @key(fields: "id") {
+    ///   id: ID
+    ///   description: String @authenticated
+    /// }
+    /// </example>
+    /// </summary>
+    /// <param name="descriptor">
+    /// The type descriptor on which this directive shall be annotated.
+    /// </param>
+    /// <returns>
+    /// Returns the type descriptor.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// The <paramref name="descriptor"/> is <c>null</c>.
+    /// </exception>
+    public static IEnumTypeDescriptor ApolloAuthenticated(this IEnumTypeDescriptor descriptor)
+    {
+        if (descriptor is null)
+        {
+            throw new ArgumentNullException(nameof(descriptor));
+        }
+        return descriptor.Directive(WellKnownTypeNames.AuthenticatedDirective);
+    }
+
+    /// <inheritdoc cref="ApolloAuthenticated(IEnumTypeDescriptor)"/>
+    public static IInterfaceFieldDescriptor ApolloAuthenticated(this IInterfaceFieldDescriptor descriptor)
+    {
+        if (descriptor is null)
+        {
+            throw new ArgumentNullException(nameof(descriptor));
+        }
+        return descriptor.Directive(WellKnownTypeNames.AuthenticatedDirective);
+    }
+
+    /// <inheritdoc cref="ApolloAuthenticated(IEnumTypeDescriptor)"/>
+    public static IInterfaceTypeDescriptor ApolloAuthenticated(this IInterfaceTypeDescriptor descriptor)
+    {
+        if (descriptor is null)
+        {
+            throw new ArgumentNullException(nameof(descriptor));
+        }
+        return descriptor.Directive(WellKnownTypeNames.AuthenticatedDirective);
+    }
+
+    /// <inheritdoc cref="ApolloAuthenticated(IEnumTypeDescriptor)"/>
+    public static IObjectFieldDescriptor ApolloAuthenticated(this IObjectFieldDescriptor descriptor)
+    {
+        if (descriptor is null)
+        {
+            throw new ArgumentNullException(nameof(descriptor));
+        }
+        return descriptor.Directive(WellKnownTypeNames.AuthenticatedDirective);
+    }
+
+    /// <inheritdoc cref="ApolloAuthenticated(IEnumTypeDescriptor)"/>
+    public static IObjectTypeDescriptor ApolloAuthenticated(this IObjectTypeDescriptor descriptor)
+    {
+        if (descriptor is null)
+        {
+            throw new ArgumentNullException(nameof(descriptor));
+        }
+        return descriptor.Directive(WellKnownTypeNames.AuthenticatedDirective);
+    }
+}

--- a/Federation/Extensions/ApolloFederationDescriptorExtensions~5.cs
+++ b/Federation/Extensions/ApolloFederationDescriptorExtensions~5.cs
@@ -1,0 +1,77 @@
+using System.Collections.Generic;
+using ApolloGraphQL.HotChocolate.Federation.Two;
+
+namespace HotChocolate.Types;
+
+/// <summary>
+/// Provides extensions for applying @requiresScopes directive on type system descriptors.
+/// </summary>
+public static partial class ApolloFederationDescriptorExtensions
+{
+    /// <summary>
+    /// Applies @requiresScopes directive to indicate that the target element is accessible only to the authenticated supergraph users with the appropriate JWT scopes.
+    /// <example>
+    /// type Foo @key(fields: "id") {
+    ///   id: ID
+    ///   description: String @requiresScopes(scopes: [["scope1"]])
+    /// }
+    /// </example>
+    /// </summary>
+    /// <param name="descriptor">
+    /// The type descriptor on which this directive shall be annotated.
+    /// </param>
+    /// <returns>
+    /// Returns the type descriptor.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// The <paramref name="descriptor"/> is <c>null</c>.
+    /// </exception>
+    public static IEnumTypeDescriptor RequiresScopes(this IEnumTypeDescriptor descriptor, List<List<Scope>> scopes)
+    {
+        if (descriptor is null)
+        {
+            throw new ArgumentNullException(nameof(descriptor));
+        }
+        return descriptor.Directive(new RequiresScopes(scopes));
+    }
+
+    /// <inheritdoc cref="RequiresScopes(IEnumTypeDescriptor, List{List{Scope}})"/>
+    public static IInterfaceFieldDescriptor RequiresScopes(this IInterfaceFieldDescriptor descriptor, List<List<Scope>> scopes)
+    {
+        if (descriptor is null)
+        {
+            throw new ArgumentNullException(nameof(descriptor));
+        }
+        return descriptor.Directive(new RequiresScopes(scopes));
+    }
+
+    /// <inheritdoc cref="RequiresScopes(IEnumTypeDescriptor, List{List{Scope}})"/>
+    public static IInterfaceTypeDescriptor RequiresScopes(this IInterfaceTypeDescriptor descriptor, List<List<Scope>> scopes)
+    {
+        if (descriptor is null)
+        {
+            throw new ArgumentNullException(nameof(descriptor));
+        }
+        return descriptor.Directive(new RequiresScopes(scopes));
+    }
+
+    /// <inheritdoc cref="RequiresScopes(IEnumTypeDescriptor, List{List{Scope}})"/>
+    public static IObjectFieldDescriptor RequiresScopes(this IObjectFieldDescriptor descriptor, List<List<Scope>> scopes)
+    {
+        if (descriptor is null)
+        {
+            throw new ArgumentNullException(nameof(descriptor));
+        }
+        return descriptor.Directive(new RequiresScopes(scopes));
+    }
+
+    /// <inheritdoc cref="RequiresScopes(IEnumTypeDescriptor, List{List{Scope}})"/>
+    public static IObjectTypeDescriptor RequiresScopes(this IObjectTypeDescriptor descriptor, List<List<Scope>> scopes)
+    {
+        if (descriptor is null)
+        {
+            throw new ArgumentNullException(nameof(descriptor));
+        }
+        return descriptor.Directive(new RequiresScopes(scopes));
+    }
+}

--- a/Federation/Extensions/ApolloFederationSchemaBuilderExtensionsV2.cs
+++ b/Federation/Extensions/ApolloFederationSchemaBuilderExtensionsV2.cs
@@ -91,7 +91,14 @@ public static class ApolloFederationSchemaBuilderExtensionsV2
         // directives
         switch (schema.FederationVersion)
         {
-            case FederationVersion.FEDERATION_25: // same as 2.3
+            case FederationVersion.FEDERATION_25:
+                {
+                    builder.AddType<ScopeType>();
+                    builder.AddType<AuthenticatedDirectiveType>();
+                    builder.AddType<RequiresScopesDirectiveType>();
+                    builder.BindRuntimeType<Scope, ScopeType>();
+                    goto case FederationVersion.FEDERATION_24;
+                }
             case FederationVersion.FEDERATION_24: // same as 2.3
             case FederationVersion.FEDERATION_23:
                 {

--- a/Federation/Properties/FederationResources.Designer.cs
+++ b/Federation/Properties/FederationResources.Designer.cs
@@ -54,11 +54,19 @@ namespace ApolloGraphQL.HotChocolate.Federation.Properties
             }
         }
 
-        internal static string Contact_Description
+        internal static string AuthenticatedDirective_Description
         {
             get
             {
-                return ResourceManager.GetString("Contact_Description", resourceCulture);
+                return ResourceManager.GetString("AuthenticatedDirective_Description", resourceCulture);
+            }
+        }
+
+        internal static string ContactDirective_Description
+        {
+            get
+            {
+                return ResourceManager.GetString("ContactDirective_Description", resourceCulture);
             }
         }
 
@@ -140,6 +148,22 @@ namespace ApolloGraphQL.HotChocolate.Federation.Properties
             get
             {
                 return ResourceManager.GetString("RequiresDirective_Description", resourceCulture);
+            }
+        }
+
+        internal static string RequiresScopesDirective_Description
+        {
+            get
+            {
+                return ResourceManager.GetString("RequiresScopesDirective_Description", resourceCulture);
+            }
+        }
+
+        internal static string ScopeType_Description
+        {
+            get
+            {
+                return ResourceManager.GetString("ScopeType_Description", resourceCulture);
             }
         }
 

--- a/Federation/Properties/FederationResources.resx
+++ b/Federation/Properties/FederationResources.resx
@@ -117,7 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Contact_Description" xml:space="preserve">
+  <data name="AuthenticatedDirective_Description" xml:space="preserve">
+    <value>Indicates to composition that the target element is accessible only to the authenticated supergraph users.</value>
+  </data>
+  <data name="ContactDirective_Description" xml:space="preserve">
     <value>Provides contact information of the owner responsible for this subgraph schema.</value>
   </data>
   <data name="ComposeDirective_Description" xml:space="preserve">
@@ -149,6 +152,12 @@
   </data>
   <data name="RequiresDirective_Description" xml:space="preserve">
     <value>Used to annotate the required input fieldset from a base type for a resolver.</value>
+  </data>
+  <data name="RequiresScopesDirective_Description" xml:space="preserve">
+    <value>Indicates to composition that the target element is accessible only to the authenticated supergraph users with the appropriate JWT scopes.</value>
+  </data>
+  <data name="ScopeType_Description" xml:space="preserve">
+    <value>Scalar representing a JWT scope</value>
   </data>
   <data name="ShareableDirective_Description" xml:space="preserve">
     <value>Indicates that given object and/or field can be resolved by multiple subgraphs.</value>

--- a/Federation/RequiresScopesAttribute.cs
+++ b/Federation/RequiresScopesAttribute.cs
@@ -1,0 +1,48 @@
+namespace ApolloGraphQL.HotChocolate.Federation;
+
+/// <summary>
+/// <code>
+/// directive @requiresScopes(scopes: [[Scope!]!]!) on
+///     ENUM
+///   | FIELD_DEFINITION
+///   | INTERFACE
+///   | OBJECT
+///   | SCALAR
+/// </code>
+/// 
+/// Directive that is used to indicate that the target element is accessible only to the authenticated supergraph users with the appropriate JWT scopes. 
+/// Refer to the <see href = "https://www.apollographql.com/docs/router/configuration/authorization#requiresscopes"> Apollo Router article</see> for additional details.
+/// <example>
+/// type Foo @key(fields: "id") {
+///   id: ID
+///   description: String @requiresScopes(scopes: [["scope1"]])
+/// }
+/// </example>
+/// </summary>
+[AttributeUsage(
+    AttributeTargets.Class
+    | AttributeTargets.Enum
+    | AttributeTargets.Interface
+    | AttributeTargets.Method
+    | AttributeTargets.Property
+    | AttributeTargets.Struct,
+    AllowMultiple = true
+)]
+public sealed class RequiresScopesAttribute : Attribute
+{
+    /// <summary>
+    /// Initializes new instance of <see cref="RequiresScopesAttribute"/> 
+    /// </summary>
+    /// <param name="scopes">
+    /// Array of required JWT scopes.
+    /// </param>
+    public RequiresScopesAttribute(string[] scopes)
+    {
+        Scopes = scopes;
+    }
+
+    /// <summary>
+    /// Retrieves array of required JWT scopes.
+    /// </summary>
+    public string[] Scopes { get; }
+}

--- a/Federation/Two/AuthenticatedDirectiveType.cs
+++ b/Federation/Two/AuthenticatedDirectiveType.cs
@@ -1,0 +1,34 @@
+using ApolloGraphQL.HotChocolate.Federation.Constants;
+using ApolloGraphQL.HotChocolate.Federation.Properties;
+
+namespace ApolloGraphQL.HotChocolate.Federation.Two;
+
+/// <summary>
+/// <code>
+/// directive @authenticated on
+///     ENUM
+///   | FIELD_DEFINITION
+///   | INTERFACE
+///   | OBJECT
+///   | SCALAR
+/// </code>
+/// 
+/// The @authenticated directive is used to indicate that the target element is accessible only to the authenticated supergraph users. 
+/// For more granular access control, see the <see cref="RequiresScopesDirectiveType">RequiresScopeDirectiveType</see> directive usage. 
+/// Refer to the <see href="https://www.apollographql.com/docs/router/configuration/authorization#authenticated">Apollo Router article</see> 
+/// for additional details.
+/// <example>
+/// type Foo @key(fields: "id") {
+///   id: ID
+///   description: String @authenticated
+/// }
+/// </example>
+/// </summary>
+public sealed class AuthenticatedDirectiveType : DirectiveType
+{
+    protected override void Configure(IDirectiveTypeDescriptor descriptor)
+        => descriptor
+            .Name(WellKnownTypeNames.AuthenticatedDirective)
+            .Description(FederationResources.AuthenticatedDirective_Description)
+            .Location(DirectiveLocation.Enum | DirectiveLocation.FieldDefinition | DirectiveLocation.Interface | DirectiveLocation.Object | DirectiveLocation.Scalar);
+}

--- a/Federation/Two/ContactDirectiveType.cs
+++ b/Federation/Two/ContactDirectiveType.cs
@@ -33,6 +33,6 @@ public sealed class ContactDirectiveType : DirectiveType<Contact>
     protected override void Configure(IDirectiveTypeDescriptor<Contact> descriptor)
         => descriptor
             .Name(WellKnownTypeNames.ContactDirective)
-            .Description(FederationResources.Contact_Description)
+            .Description(FederationResources.ContactDirective_Description)
             .Location(DirectiveLocation.Schema);
 }

--- a/Federation/Two/RequiresScopes.cs
+++ b/Federation/Two/RequiresScopes.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+
+namespace ApolloGraphQL.HotChocolate.Federation.Two;
+
+/// <summary>
+/// Object representation of @requiresScopes directive.
+/// </summary>
+public sealed class RequiresScopes
+{
+    /// <summary>
+    /// Initializes new instance of <see cref="RequiresScopes"/> 
+    /// </summary>
+    /// <param name="scopes">
+    /// List of a list of required JWT scopes.
+    /// </param>
+    public RequiresScopes(List<List<Scope>> scopes)
+    {
+        Scopes = scopes;
+    }
+
+    /// <summary>
+    /// Retrieves list of a list of required JWT scopes.
+    /// </summary>
+    public List<List<Scope>> Scopes { get; }
+}

--- a/Federation/Two/RequiresScopesDirectiveType.cs
+++ b/Federation/Two/RequiresScopesDirectiveType.cs
@@ -1,0 +1,32 @@
+using ApolloGraphQL.HotChocolate.Federation.Constants;
+using ApolloGraphQL.HotChocolate.Federation.Properties;
+
+namespace ApolloGraphQL.HotChocolate.Federation.Two;
+
+/// <summary>
+/// <code>
+/// directive @@requiresScopes(scopes: [[Scope!]!]!) on
+///     ENUM
+///   | FIELD_DEFINITION
+///   | INTERFACE
+///   | OBJECT
+///   | SCALAR
+/// </code>
+/// 
+/// Directive that is used to indicate that the target element is accessible only to the authenticated supergraph users with the appropriate JWT scopes. 
+/// Refer to the <see href = "https://www.apollographql.com/docs/router/configuration/authorization#requiresscopes"> Apollo Router article</see> for additional details.
+/// <example>
+/// type Foo @key(fields: "id") {
+///   id: ID
+///   description: String @requiresScopes(scopes: [["scope1"]])
+/// }
+/// </example>
+/// </summary>
+public sealed class RequiresScopesDirectiveType : DirectiveType<RequiresScopes>
+{
+    protected override void Configure(IDirectiveTypeDescriptor<RequiresScopes> descriptor)
+        => descriptor
+            .Name(WellKnownTypeNames.RequiresScopes)
+            .Description(FederationResources.RequiresScopesDirective_Description)
+            .Location(DirectiveLocation.Enum | DirectiveLocation.FieldDefinition | DirectiveLocation.Interface | DirectiveLocation.Object | DirectiveLocation.Scalar);
+}

--- a/Federation/Two/Scope.cs
+++ b/Federation/Two/Scope.cs
@@ -1,0 +1,23 @@
+namespace ApolloGraphQL.HotChocolate.Federation.Two;
+
+/// <summary>
+/// Scalar <code>Scope</code> representation.
+/// </summary>
+public sealed class Scope
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="Scope"/>.
+    /// </summary>
+    /// <param name="value">
+    /// Scope value
+    /// </param>
+    public Scope(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// Retrieve scope value
+    /// </summary>
+    public string Value { get; }
+}

--- a/Federation/Two/ScopeType.cs
+++ b/Federation/Two/ScopeType.cs
@@ -1,0 +1,42 @@
+using ApolloGraphQL.HotChocolate.Federation.Constants;
+using ApolloGraphQL.HotChocolate.Federation.Properties;
+using HotChocolate.Language;
+
+namespace ApolloGraphQL.HotChocolate.Federation.Two;
+
+/// <summary>
+/// The <code>Scope</code> scalar representing a JWT scope. Serializes as a string.
+/// </summary>
+public sealed class ScopeType : ScalarType<Scope, StringValueNode>
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="ScopeType"/>.
+    /// </summary>
+    public ScopeType() : this(WellKnownTypeNames.Scope)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="ScopeType"/>.
+    /// </summary>
+    /// <param name="name">
+    /// Scalar name
+    /// </param>
+    /// <param name="bind">
+    /// Defines if this scalar shall bind implicitly to <see cref="Scope"/>.
+    /// </param>
+    public ScopeType(string name, BindingBehavior bind = BindingBehavior.Explicit)
+        : base(name, bind)
+    {
+        Description = FederationResources.ScopeType_Description;
+    }
+
+    protected override Scope ParseLiteral(StringValueNode valueSyntax)
+        => new Scope(valueSyntax.Value);
+
+    public override IValueNode ParseResult(object? resultValue)
+        => ParseValue(resultValue);
+
+    protected override StringValueNode ParseValue(Scope runtimeValue)
+        => new StringValueNode(runtimeValue.Value);
+}

--- a/README.md
+++ b/README.md
@@ -109,12 +109,14 @@ Federation v1 directives
 Federation v2 directives (includes all of the v1 directives)
 
 * `ApolloTag` applicable on schema, see [`@tag` documentation](https://www.apollographql.com/docs/federation/federated-types/federated-directives#tag)
-* `ComposeDirective` applicable on schema, see [`@composeDirective` documentation](https://www.apollographql.com/docs/federation/federated-types/federated-directives#composedirective)
+* `ApolloAuthenticated` **(since v2.5)** applicable on enum, field, interface and object, [`@authenticated` documentation](https://www.apollographql.com/docs/federation/federated-types/federated-directives/#authenticated)
+* `ComposeDirective` **(since v2.1)** applicable on schema, see [`@composeDirective` documentation](https://www.apollographql.com/docs/federation/federated-types/federated-directives#composedirective)
 * `Contact` applicable on schema, see [`@contact` usage](#providing-subgraph-contact-information)
 * `Inaccessible` applicable on all type definitions, see [`@inaccessible` documentation](https://www.apollographql.com/docs/federation/federated-types/federated-directives#inaccessible)
-* `InterfaceObject` applicable on objects, see [`@interfaceObject` documentation](https://www.apollographql.com/docs/federation/federated-types/federated-directives#interfaceobject)
+* `InterfaceObject` **(since v2.3)** applicable on objects, see [`@interfaceObject` documentation](https://www.apollographql.com/docs/federation/federated-types/federated-directives#interfaceobject)
 * `KeyInterface` applicable on interfaces, see [entity interface `@key` documentation](https://www.apollographql.com/docs/federation/federated-types/interfaces)
 * `Link` applicable on schema, see [`@link` documentation](https://www.apollographql.com/docs/federation/federated-types/federated-directives#the-link-directive)
+* `RequiresScopes` **(since v2.5)** applicable on enum, field, interface and object, [`@requiresScopes` documentation](https://www.apollographql.com/docs/federation/federated-types/federated-directives/#requiresscopes)
 * `Shareable` applicable on schema, see [`@shareable` documentation](https://www.apollographql.com/docs/federation/federated-types/federated-directives#shareable)
 
 Entity resolution
@@ -184,12 +186,14 @@ Federation v1 directives
 Federation v2 directives (includes all of the v1 directives)
 
 * `ApolloTag` applicable on all type definitions, see [`@tag` documentation](https://www.apollographql.com/docs/federation/federated-types/federated-directives#tag)
-* `ComposeDirective(name)` applicable on schema, see [`@composeDirective` documentation](https://www.apollographql.com/docs/federation/federated-types/federated-directives#composedirective)
+* `ApolloAuthenticated` **(since v2.5)** applicable on enum, field, interface and object, [`@authenticated` documentation](https://www.apollographql.com/docs/federation/federated-types/federated-directives/#authenticated)
+* `ComposeDirective(name)` **(since v2.1)** applicable on schema, see [`@composeDirective` documentation](https://www.apollographql.com/docs/federation/federated-types/federated-directives#composedirective)
 * `Contact(name, url?, description?)` applicable on schema, see [`@contact` usage](#providing-subgraph-contact-information)
 * `Inaccessible` applicable on all type definitions, see [`@inaccessible` documentation](https://www.apollographql.com/docs/federation/federated-types/federated-directives#inaccessible)
-* `InterfaceObject` applicable on objects, see [`@interfaceObject` documentation](https://www.apollographql.com/docs/federation/federated-types/federated-directives#interfaceobject)
+* `InterfaceObject` **(since v2.3)** applicable on objects, see [`@interfaceObject` documentation](https://www.apollographql.com/docs/federation/federated-types/federated-directives#interfaceobject)
 * `Key(fieldset, resolvable?)` applicable on objects, see [`@key` documentation](https://www.apollographql.com/docs/federation/federated-types/federated-directives#key)
 * `Link(url, [import]?)` applicable on schema, see [`@link` documentation](https://www.apollographql.com/docs/federation/federated-types/federated-directives#the-link-directive)
+* `RequiresScopes(scopes)` **(since v2.5)** applicable on enum, field, interface and object, [`@requiresScopes` documentation](https://www.apollographql.com/docs/federation/federated-types/federated-directives/#requiresscopes)
 * `Shareable` applicable on fields and objects, see [`@shareable` documentation](https://www.apollographql.com/docs/federation/federated-types/federated-directives#shareable)
 
 Entity resolution
@@ -322,6 +326,29 @@ public class Product
     public string Id { get; set; }
 
     public List<string> Reviews { get; set; }
+}
+```
+
+#### Access control through @requiresScopes
+
+The `@requiresScopes` directive is used to indicate that the target element is accessible only to the authenticated supergraph users with the appropriate JWT scopes. 
+Refer to the [Apollo Router article](https://www.apollographql.com/docs/router/configuration/authorization#requiresscopes) for additional details.
+
+```csharp
+public class Query
+{
+    [RequiresScopes(scopes: new string[] { "scope1, scope2", "scope3" })]
+    [RequiresScopes(scopes: new string[] { "scope4" })]
+    public Product? GetProduct([ID] string id, Data repository)
+        => repository.Products.FirstOrDefault(t => t.Id.Equals(id));
+}
+```
+
+This will generate the following schema
+
+```graphql
+type Query {
+    product(id: ID!): Product @requiresScopes(scopes: [ [ "scope1, scope2", "scope3" ], [ "scope4" ] ])
 }
 ```
 


### PR DESCRIPTION
Add support for Federation v2.5 directives

* `@authenticated` - indicates that target element is only accessible to the authenticated supergraph users, see [docs for details](https://www.apollographql.com/docs/federation/federated-types/federated-directives#authenticated)
* `@requiresScopes` - indicates that target element is only accessible to the authenticated supergraph users with the appropriate JWT scopes, see [docs for details](https://www.apollographql.com/docs/federation/federated-types/federated-directives#requiresscopes)