### PR TITLE
chore: explicitly use IdType

### DIFF
--- a/Compatibility/AnnotationBased/Types/CaseStudy.cs
+++ b/Compatibility/AnnotationBased/Types/CaseStudy.cs
@@ -9,7 +9,8 @@ public class CaseStudy
         Description = description;
     }
 
-    [ID]
+    [GraphQLType(typeof(IdType))]
+    [GraphQLNonNullType]
     public string CaseNumber { get; }
     public string? Description { get; }
 

--- a/Compatibility/AnnotationBased/Types/Inventory.cs
+++ b/Compatibility/AnnotationBased/Types/Inventory.cs
@@ -12,7 +12,8 @@ public class Inventory
         Id = id;
     }
 
-    [ID]
+    [GraphQLType(typeof(IdType))]
+    [GraphQLNonNullType]
     public string Id { get; }
 
     public List<DeprecatedProduct> DeprecatedProducts(Data repository) => repository.DeprecatedProducts;

--- a/Compatibility/AnnotationBased/Types/Product.cs
+++ b/Compatibility/AnnotationBased/Types/Product.cs
@@ -20,7 +20,8 @@ public class Product
         Research = research;
     }
 
-    [ID]
+    [GraphQLType(typeof(IdType))]
+    [GraphQLNonNullType]
     public string Id { get; }
 
     public string? Sku { get; }

--- a/Compatibility/AnnotationBased/Types/ProductVariation.cs
+++ b/Compatibility/AnnotationBased/Types/ProductVariation.cs
@@ -7,6 +7,7 @@ public class ProductVariation
         Id = id;
     }
 
-    [ID]
+    [GraphQLType(typeof(IdType))]
+    [GraphQLNonNullType]
     public string Id { get; }
 }

--- a/Compatibility/AnnotationBased/Types/Query.cs
+++ b/Compatibility/AnnotationBased/Types/Query.cs
@@ -2,7 +2,7 @@ namespace Products;
 
 public class Query
 {
-    public Product? GetProduct([ID] string id, Data repository)
+    public Product? GetProduct([GraphQLType(typeof(IdType))][GraphQLNonNullType] string id, Data repository)
         => repository.Products.FirstOrDefault(t => t.Id.Equals(id));
 
     [GraphQLDeprecated("Use product query instead")]

--- a/Compatibility/AnnotationBased/Types/User.cs
+++ b/Compatibility/AnnotationBased/Types/User.cs
@@ -22,7 +22,8 @@ public class User
         return null;
     }
 
-    [ID]
+    [GraphQLType(typeof(IdType))]
+    [GraphQLNonNullType]
     [External]
     public string Email { get; set; }
 

--- a/Compatibility/CodeFirst/Types/Query.cs
+++ b/Compatibility/CodeFirst/Types/Query.cs
@@ -2,7 +2,7 @@ namespace Products;
 
 public class Query
 {
-    public Product? GetProduct([ID] string id, Data repository)
+    public Product? GetProduct(string id, Data repository)
         => repository.Products.FirstOrDefault(t => t.Id.Equals(id));
 
     public DeprecatedProduct? GetDeprecatedProduct(string sku, string package, Data repository)
@@ -14,6 +14,7 @@ public class QueryType : ObjectType<Query>
     protected override void Configure(IObjectTypeDescriptor<Query> descriptor)
     {
         descriptor.Field(q => q.GetProduct(default!, default!))
+            .Argument("id", a => a.Type<NonNullType<IdType>>())
             .Type<ProductType>();
         descriptor.Field(q => q.GetDeprecatedProduct(default!, default!, default!))
             .Type<DeprecatedProductType>()

--- a/Federation.Tests/CertificationSchema/AnnotationBased/Types/Product.cs
+++ b/Federation.Tests/CertificationSchema/AnnotationBased/Types/Product.cs
@@ -1,5 +1,6 @@
 using System.Linq;
-using HotChocolate.Types.Relay;
+using HotChocolate;
+using HotChocolate.Types;
 
 namespace ApolloGraphQL.HotChocolate.Federation.CertificationSchema.AnnotationBased.Types;
 
@@ -16,7 +17,8 @@ public class Product
         Variation = new(variation);
     }
 
-    [ID]
+    [GraphQLType(typeof(IdType))]
+    [GraphQLNonNullType]
     public string Id { get; }
 
     public string? Sku { get; }

--- a/Federation.Tests/CertificationSchema/AnnotationBased/Types/ProductVariation.cs
+++ b/Federation.Tests/CertificationSchema/AnnotationBased/Types/ProductVariation.cs
@@ -1,4 +1,5 @@
-using HotChocolate.Types.Relay;
+using HotChocolate;
+using HotChocolate.Types;
 
 namespace ApolloGraphQL.HotChocolate.Federation.CertificationSchema.AnnotationBased.Types;
 
@@ -9,6 +10,7 @@ public class ProductVariation
         Id = id;
     }
 
-    [ID]
+    [GraphQLType(typeof(IdType))]
+    [GraphQLNonNullType]
     public string Id { get; }
 }

--- a/Federation.Tests/CertificationSchema/AnnotationBased/Types/Query.cs
+++ b/Federation.Tests/CertificationSchema/AnnotationBased/Types/Query.cs
@@ -1,11 +1,12 @@
-﻿using System.Linq;
-using HotChocolate.Types.Relay;
+﻿using HotChocolate;
+using HotChocolate.Types;
+using System.Linq;
 
 namespace ApolloGraphQL.HotChocolate.Federation.CertificationSchema.AnnotationBased.Types;
 
 [ExtendServiceType]
 public class Query
 {
-    public Product? GetProduct([ID] string id, Data repository)
+    public Product? GetProduct([GraphQLType(typeof(IdType))][GraphQLNonNullType] string id, Data repository)
         => repository.Products.FirstOrDefault(t => t.Id.Equals(id));
 }

--- a/Federation.Tests/CertificationSchema/AnnotationBased/Types/User.cs
+++ b/Federation.Tests/CertificationSchema/AnnotationBased/Types/User.cs
@@ -1,4 +1,5 @@
-using HotChocolate.Types.Relay;
+using HotChocolate;
+using HotChocolate.Types;
 
 namespace ApolloGraphQL.HotChocolate.Federation.CertificationSchema.AnnotationBased.Types;
 
@@ -16,7 +17,8 @@ public class User
         TotalProductsCreated = totalProductsCreated;
     }
 
-    [ID]
+    [GraphQLType(typeof(IdType))]
+    [GraphQLNonNullType]
     [External]
     public string Email { get; set; } = default!;
 

--- a/Federation.Tests/CertificationSchema/CodeFirst/Types/ProductType.cs
+++ b/Federation.Tests/CertificationSchema/CodeFirst/Types/ProductType.cs
@@ -15,6 +15,9 @@ public class ProductType : ObjectType<Product>
             .Field(t => t.Id)
             .ID();
 
+        descriptor.Field(p => p.Variation)
+            .Type<ProductVariationType>();
+
         descriptor
             .Key("sku package")
             .ResolveReferenceWith(t => GetProductByPackage(default!, default!, default!));

--- a/Federation.Tests/CertificationSchema/CodeFirst/Types/ProductVariation.cs
+++ b/Federation.Tests/CertificationSchema/CodeFirst/Types/ProductVariation.cs
@@ -1,4 +1,4 @@
-using HotChocolate.Types.Relay;
+using HotChocolate.Types;
 
 namespace ApolloGraphQL.HotChocolate.Federation.CertificationSchema.CodeFirst.Types;
 
@@ -9,6 +9,13 @@ public class ProductVariation
         Id = id;
     }
 
-    [ID]
     public string Id { get; }
+}
+
+public class ProductVariationType : ObjectType<ProductVariation>
+{
+    protected override void Configure(IObjectTypeDescriptor<ProductVariation> descriptor)
+    {
+        descriptor.Field(v => v.Id).Type<NonNullType<IdType>>();
+    }
 }

--- a/Federation.Tests/CertificationSchema/CodeFirst/Types/User.cs
+++ b/Federation.Tests/CertificationSchema/CodeFirst/Types/User.cs
@@ -1,5 +1,3 @@
-using HotChocolate.Types.Relay;
-
 namespace ApolloGraphQL.HotChocolate.Federation.CertificationSchema.CodeFirst.Types;
 
 public class User

--- a/Federation.Tests/CertificationSchema/CodeFirst/__snapshots__/CertificationTests.Schema_Snapshot.snap
+++ b/Federation.Tests/CertificationSchema/CodeFirst/__snapshots__/CertificationTests.Schema_Snapshot.snap
@@ -4,10 +4,10 @@
 
 type Product @key(fields: "id") @key(fields: "sku package") @key(fields: "sku variation { id }") {
   id: ID!
+  variation: ProductVariation
   createdBy: User! @provides(fields: "totalProductsCreated")
   sku: String
   package: String
-  variation: ProductVariation
   dimensions: ProductDimension
 }
 

--- a/Federation.Tests/CertificationSchema/CodeFirst/__snapshots__/CertificationTests.Subgraph_SDL.snap
+++ b/Federation.Tests/CertificationSchema/CodeFirst/__snapshots__/CertificationTests.Subgraph_SDL.snap
@@ -1,9 +1,9 @@
 ﻿type Product @key(fields: "id") @key(fields: "sku package") @key(fields: "sku variation { id }") {
   id: ID!
+  variation: ProductVariation
   createdBy: User! @provides(fields: "totalProductsCreated")
   sku: String
   package: String
-  variation: ProductVariation
   dimensions: ProductDimension
 }
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ public class Product
         Description = description;
     }
 
-    [ID]
+    [GraphQLType(typeof(IdType))]
+    [GraphQLNonNullType]
     public string Id { get; }
 
     public string Name { get; }
@@ -139,7 +140,8 @@ public class Product
         Description = description;
     }
 
-    [ID]
+    [GraphQLType(typeof(IdType))]
+    [GraphQLNonNullType]
     public string Id { get; }
 
     public string Name { get; }
@@ -296,7 +298,8 @@ In a subgraph defininig the interface we need to apply `@key`
 [KeyInterface("id")]
 public interface Product
 {
-    [ID]
+    [GraphQLType(typeof(IdType))]
+    [GraphQLNonNullType]
     string Id { get; }
 
     string Name { get; }
@@ -305,7 +308,8 @@ public interface Product
 [Key("id")]
 public class Book : Product
 {
-    [ID]
+    [GraphQLType(typeof(IdType))]
+    [GraphQLNonNullType]
     public string Id { get; set; }
 
     public string Name { get; set; }
@@ -322,7 +326,8 @@ entity that implements your interface (e.g. adding `Reviews` field to all `Produ
 [InterfaceObject]
 public class Product
 {
-    [ID]
+    [GraphQLType(typeof(IdType))]
+    [GraphQLNonNullType]
     public string Id { get; set; }
 
     public List<string> Reviews { get; set; }
@@ -339,7 +344,7 @@ public class Query
 {
     [RequiresScopes(scopes: new string[] { "scope1, scope2", "scope3" })]
     [RequiresScopes(scopes: new string[] { "scope4" })]
-    public Product? GetProduct([ID] string id, Data repository)
+    public Product? GetProduct([GraphQLType(typeof(IdType))][GraphQLNonNullType] string id, Data repository)
         => repository.Products.FirstOrDefault(t => t.Id.Equals(id));
 }
 ```
@@ -387,7 +392,7 @@ with those custom values.
 ```csharp
 public class CustomQuery
 {
-    public Foo? GetFoo([ID] string id, Data repository)
+    public Foo? GetFoo([GraphQLType(typeof(IdType))][GraphQLNonNullType] string id, Data repository)
         => repository.Foos.FirstOrDefault(t => t.Id.Equals(id));
 }
 


### PR DESCRIPTION
HotChocolate `[ID]` attribute is within *relay* package. To avoid confusion we should use the default `IdType` instead.