### PR TITLE
Enable Source link for debugging enhancements

### DIFF
--- a/Federation/ApolloGraphQL.HotChocolate.Federation.csproj
+++ b/Federation/ApolloGraphQL.HotChocolate.Federation.csproj
@@ -7,14 +7,18 @@
     <AssemblyName>ApolloGraphQL.HotChocolate.Federation</AssemblyName>
     <Description>Apollo Federation Subgraph support for HotChocolate.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>
     <InternalsVisibleTo Include="ApolloGraphQL.HotChocolate.Federation.Tests" />
   </ItemGroup>
 
-  <ItemGroup> 
+  <ItemGroup>
     <PackageReference Include="HotChocolate" Version="13.6.1" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- [Source Link](https://learn.microsoft.com/en-us/dotnet/standard/library-guidance/sourcelink) reference
> Source Link is a technology that enables source code debugging of .NET assemblies from NuGet by developers. Source Link executes when creating the NuGet package and embeds source control metadata inside assemblies and the package. Developers who download the package and have Source Link enabled in Visual Studio can step into its source code. Source Link provides source control metadata to create a great debugging experience.
- See example from Newtonsoft.Json https://github.com/JamesNK/Newtonsoft.Json/blob/master/Src/Newtonsoft.Json/Newtonsoft.Json.csproj
- Also producing [symbol packages (.snupkg)](https://learn.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg?source=recommendations) to include debug symbols